### PR TITLE
obsługa secret dostępowego do prywatnego rejestru obrazów obsługa secret do prywatnego rejestru obrazów + projekt triva

### DIFF
--- a/charts/soneta/templates/_helpers.tpl
+++ b/charts/soneta/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Other
 {{- $component := index . 1 -}}
 {{- $image := include "soneta.image.name" . -}}
 {{- $postfix := include "soneta.image.postfix" . -}}
-{{ $.Values.image.repository }}soneta/{{ $image }}.{{ $.Values.image.product}}:{{ $.Values.image.tag }}{{ $postfix }}
+{{ $.Values.image.repository }}{{ $.Values.image.organization | default "soneta" }}/{{ $image }}.{{ $.Values.image.product}}:{{ $.Values.image.tag }}{{ $postfix }}
 {{- end -}}
 
 {{- define "soneta.web.enpointProtocol" -}}

--- a/charts/soneta/templates/_pod.tpl
+++ b/charts/soneta/templates/_pod.tpl
@@ -103,6 +103,10 @@ spec:
         {{- include "soneta.volumeMounts.component" . | indent 8 }}
   volumes:
     {{- include "soneta.volumes.component" . | indent 4 }}
+{{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   nodeSelector:
     kubernetes.io/os: {{ $os }}
 {{- with $.Values.nodeSelector }}

--- a/charts/soneta/values.schema.json
+++ b/charts/soneta/values.schema.json
@@ -125,6 +125,11 @@
                     "default": "",
                     "description": "Repository url, if empty then dockerhub"
                 },
+                "organization": {
+                    "type": "string",
+                    "default": "soneta",
+                    "description": "Path segment after the registry host (Docker Hub organization, or project name in a private registry). Defaults to 'soneta'; change only when images are published under a different name."
+                },
                 "product": {
                     "type" :"string",
                     "default": "standard",
@@ -174,7 +179,18 @@
 
         "imagePullSecrets": {
             "type": "array",
-            "description": "List of Kubernetes secrets used to pull images from private registries."
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of a kubernetes.io/dockerconfigjson Secret in the release namespace."
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            },
+            "description": "Optional. Only needed when images are pulled from a registry that requires authentication; leave empty for public images. Each entry is an object with a 'name' key, e.g. [{name: regcred}]. The Secret must exist in the same namespace as the release."
         },
 
         "nameOverride": {

--- a/charts/soneta/values.yaml
+++ b/charts/soneta/values.yaml
@@ -11,6 +11,7 @@ image:
   webTagPostfix: -alpine
   serverTagPostfix: -alpine
   repository: ""
+  organization: "soneta"
   scheduler: false
   webapi: false
   webwcf: false


### PR DESCRIPTION
Obsługa prywatnego rejestru obrazów (organization + imagePullSecrets)

Co się zmienia

- Segment organizacji w nazwie obrazu (dotąd zahardkodowany soneta/) jest teraz parametryzowany przez image.organization (domyślnie "soneta" — zachowanie identyczne jak wcześniej).
- Dodano opcjonalne imagePullSecrets w specyfikacji poda (_pod.tpl) — pozwala pobierać obrazy z rejestru wymagającego uwierzytelnienia.
- values.schema.json uzupełniony o oba pola, opisy sformułowane neutralnie (bez wskazywania konkretnego rejestru — chart jest publiczny, domyślnym źródłem obrazów pozostaje Docker Hub).

Jak to działa

- repository: "" + organization: "soneta" → soneta/web.standard:tag → Docker Hub (bez zmian).
- repository: "registry.soneta.pl/" + organization: "..." → obraz z prywatnego rejestru; w połączeniu z imagePullSecrets: [{name: regcred}] pozwala pobierać obrazy wymagające uwierzytelnienia.

Kompatybilność wsteczna

Bez zmian w values.yaml zachowanie chartu nie zmienia się — domyślny organization: "soneta" odtwarza dotychczasowy zahardkodowany segment nazwy obrazu.